### PR TITLE
Added more unescape functionality

### DIFF
--- a/ui/src/components/common/Grapher.js
+++ b/ui/src/components/common/Grapher.js
@@ -3,6 +3,7 @@ import dagreD3 from 'dagre-d3'
 import d3 from 'd3'
 import {Tabs, Tab, Table} from 'react-bootstrap';
 import Clipboard from 'clipboard';
+import UnescapeButton from './UnescapeButton'
 
 new Clipboard('.btn');
 
@@ -219,7 +220,7 @@ class Grapher extends Component {
                                 </tr>
                                 <tr>
                                     <th colSpan="4">Input <i title="copy to clipboard" className="btn fa fa-clipboard"
-                                                             data-clipboard-target="#t_input"/></th>
+                                                             data-clipboard-target="#t_input"/><UnescapeButton target="t_input" /></th>
                                 </tr>
                                 <tr>
                                     <td colSpan="4">
@@ -229,7 +230,7 @@ class Grapher extends Component {
                                 </tr>
                                 <tr>
                                     <th colSpan="4">Output <i title="copy to clipboard" className="btn fa fa-clipboard"
-                                                              data-clipboard-target="#t_output"/></th>
+                                                              data-clipboard-target="#t_output"/><UnescapeButton target="t_output" /></th>
                                 </tr>
                                 <tr>
                                     <td colSpan="4" >
@@ -242,12 +243,12 @@ class Grapher extends Component {
                         </Tab>
                         <Tab eventKey={2} title="JSON"><br/>
                             <i title="copy to clipboard" className="btn fa fa-clipboard"
-                               data-clipboard-target="#t_json"/>
+                               data-clipboard-target="#t_json"/><UnescapeButton target="t_json" />
                             <pre id="t_json">{JSON.stringify(this.state.selectedTask, null, 3)}</pre>
                         </Tab>
                         <Tab eventKey={3} title="Logs"><br/>
                             <i title="copy to clipboard" className="btn fa fa-clipboard"
-                               data-clipboard-target="#t_logs"/>
+                               data-clipboard-target="#t_logs"/><UnescapeButton target="t_logs" />
                             <pre id="t_logs">{JSON.stringify(this.state.selectedTask.logs, null, 3)}</pre>
                         </Tab>
                     </Tabs>

--- a/ui/src/components/common/UnescapeButton.js
+++ b/ui/src/components/common/UnescapeButton.js
@@ -1,0 +1,37 @@
+import React, {Component} from 'react';
+import unescapeJs from "unescape-js";
+
+class UnescapeButton extends Component {
+    constructor(props) {
+        super(props)
+
+        this.doUnescape = this.doUnescape.bind(this);
+        
+
+        this.state = {
+            isUnescaped: false
+        }
+    }
+
+    doUnescape() {
+        let newval = !this.state.isUnescaped
+        this.setState({
+            isUnescaped: newval
+        })
+        this.forceUpdate()
+        if(!this.state.isUnescaped){
+            document.getElementById(this.props.target).setAttribute('data-escaped', document.getElementById(this.props.target).innerHTML)
+            document.getElementById(this.props.target).innerHTML = unescapeJs(document.getElementById(this.props.target).innerHTML);
+        } else {
+            document.getElementById(this.props.target).innerHTML = document.getElementById(this.props.target).getAttribute('data-escaped')
+        }
+    }
+
+    render() {
+        return(
+            <button onClick={(e) => this.doUnescape()} className='btn btn-default btn-xs'>{this.state.isUnescaped ? 'Escape' : 'Unescape'}</button>
+        )
+    }
+}
+
+export default UnescapeButton

--- a/ui/src/components/workflow/executions/WorkflowDetails.js
+++ b/ui/src/components/workflow/executions/WorkflowDetails.js
@@ -13,7 +13,7 @@ import Tab from "../../common/Tab";
 import TabContainer from "../../common/TabContainer";
 import { startWorkflow } from '../../../actions/WorkflowActions';
 import {Link} from "react-router";
-import unescapeJs from "unescape-js";
+import UnescapeButton from '../../common/UnescapeButton'
 
 new Clipboard('.btn');
 
@@ -53,12 +53,12 @@ function popoverLink(cell, row) {
     return (<OverlayTrigger trigger="click" rootClose placement="left" overlay={
         <Popover id="task-details-wfd" title="Task Details" style={{width: '800px'}}>
             <Panel header={<span><span>Task Input</span> <i title="copy to clipboard" className="btn fa fa-clipboard"
-                                                            data-clipboard-target="#input"/></span>}>
+                                                            data-clipboard-target="#input"/><UnescapeButton target='input' /></span>}>
 
                 <span className="small"><pre id="input">{JSON.stringify(row.inputData, null, 2)}</pre></span>
             </Panel>
             <Panel header={<span><span>Task Output</span> <i title="copy to clipboard" className="btn fa fa-clipboard"
-                                                             data-clipboard-target="#output"/></span>}>
+                                                             data-clipboard-target="#output"/><UnescapeButton target='output' /></span>}>
                 <span className="small"><pre id="output">{JSON.stringify(row.outputData, null, 2)}</pre></span>
             </Panel>
             <Panel header="Task Failure Reason (if any)">
@@ -103,9 +103,6 @@ class WorkflowDetails extends Component {
     constructor(props) {
         super(props);
 
-        this.startWorkflow1 = this.startWorkflow1.bind(this);
-        this.doUnescape = this.doUnescape.bind(this);
-
         this.state = {
             loading: this.props.starting,
             log: this.props.res,
@@ -114,10 +111,7 @@ class WorkflowDetails extends Component {
             workflowForm: {
                 labels: [],
                 values: []
-            },
-            unescapeInput: false,
-            unescapeOutput: false,
-            unescapeJSON: false
+            }
         };
 
         http.get('/api/sys/').then((data) => {
@@ -213,22 +207,14 @@ class WorkflowDetails extends Component {
     }
 
     doUnescape(e, option) {
-        let newval;
-        switch(option) {
-            case 1: {
-                newval = !this.state.unescapeInput;
-                this.setState({unescapeInput: newval});
-            }
-            case 2: {
-                newval = !this.state.unescapeOutput;
-                this.setState({unescapeOutput: newval});
-            }
-            case 3: {
-                newval = !this.state.unescapeJSON;
-                this.setState({unescapeJSON: newval});
-            }
+        if(option == 1) {
+            let newval = !this.state.unescapeInput;
+            this.setState({unescapeInput: newval});
+        } else {
+            let newval = !this.state.unescapeOutput;
+            this.setState({unescapeOutput: newval});
         }
-            //this.forceUpdate();
+        this.forceUpdate();
     }
 
     render() {
@@ -354,11 +340,11 @@ class WorkflowDetails extends Component {
                         <div>
                             <strong>Workflow Input <i title="copy to clipboard" className="btn fa fa-clipboard"
                                                       data-clipboard-target="#wfinput"/></strong>
-                                                      <button onClick={(e) => this.doUnescape(e, 1)} className='btn btn-default btn-xs'>{this.state.unescapeInput ? 'Escape' : 'Unescape'}</button>
+                                                      <UnescapeButton target='wfinput' />
                             <pre style={{height: '200px'}} id="wfinput">{this.state.unescapeInput ? unescapeJs(JSON.stringify(wf.input, null, 3)) : JSON.stringify(wf.input, null, 3)}</pre>
                             <strong>Workflow Output <i title="copy to clipboard" className="btn fa fa-clipboard"
                                                        data-clipboard-target="#wfoutput"/></strong>
-                                                       <button onClick={(e) => this.doUnescape(e, 2)} className='btn btn-default btn-xs'>{this.state.unescapeOutput ? 'Escape' : 'Unescape'}</button>
+                                                       <UnescapeButton target='wfoutput' />
                             <pre style={{height: '200px'}}
                                  id="wfoutput">{this.state.unescapeOutput ? unescapeJs(JSON.stringify((wf.output) == null ? {} : wf.output, null, 3)) : JSON.stringify(wf.output == null ? {} : wf.output, null, 3)}</pre>
                             {wf.status === 'FAILED' ? <div><strong>Workflow Faiure Reason (if any)</strong>
@@ -368,8 +354,9 @@ class WorkflowDetails extends Component {
                     </Tab>
                     <Tab eventKey={4} title="JSON">
                         <i title="copy to clipboard" className="btn fa fa-clipboard"
-                           data-clipboard-target="#fulljson"/><button onClick={(e) => this.doUnescape(e, 3)} className='btn btn-default btn-xs'>{this.state.unescapeJSON ? 'Escape' : 'Unescape'}</button>
-                        <pre style={{height: '80%'}} id="fulljson">{this.state.unescapeJSON ? unescapeJs(JSON.stringify(wf, null, 3)) : JSON.stringify(wf, null, 3)}</pre>
+                           data-clipboard-target="#fulljson"/>
+                           <UnescapeButton target='fulljson' />
+                        <pre style={{height: '80%'}} id="fulljson">{JSON.stringify(wf, null, 3)}</pre>
                     </Tab>
                     <Tab eventKey={5} title="Edit input">
                         &nbsp;&nbsp;

--- a/ui/src/components/workflow/executions/WorkflowDetails.js
+++ b/ui/src/components/workflow/executions/WorkflowDetails.js
@@ -116,7 +116,8 @@ class WorkflowDetails extends Component {
                 values: []
             },
             unescapeInput: false,
-            unescapeOutput: false
+            unescapeOutput: false,
+            unescapeJSON: false
         };
 
         http.get('/api/sys/').then((data) => {
@@ -212,14 +213,22 @@ class WorkflowDetails extends Component {
     }
 
     doUnescape(e, option) {
-        if(option == 1) {
-            let newval = !this.state.unescapeInput;
-            this.setState({unescapeInput: newval});
-        } else {
-            let newval = !this.state.unescapeOutput;
-            this.setState({unescapeOutput: newval});
+        let newval;
+        switch(option) {
+            case 1: {
+                newval = !this.state.unescapeInput;
+                this.setState({unescapeInput: newval});
+            }
+            case 2: {
+                newval = !this.state.unescapeOutput;
+                this.setState({unescapeOutput: newval});
+            }
+            case 3: {
+                newval = !this.state.unescapeJSON;
+                this.setState({unescapeJSON: newval});
+            }
         }
-        this.forceUpdate();
+            //this.forceUpdate();
     }
 
     render() {
@@ -359,8 +368,8 @@ class WorkflowDetails extends Component {
                     </Tab>
                     <Tab eventKey={4} title="JSON">
                         <i title="copy to clipboard" className="btn fa fa-clipboard"
-                           data-clipboard-target="#fulljson"/>
-                        <pre style={{height: '80%'}} id="fulljson">{JSON.stringify(wf, null, 3)}</pre>
+                           data-clipboard-target="#fulljson"/><button onClick={(e) => this.doUnescape(e, 3)} className='btn btn-default btn-xs'>{this.state.unescapeJSON ? 'Escape' : 'Unescape'}</button>
+                        <pre style={{height: '80%'}} id="fulljson">{this.state.unescapeJSON ? unescapeJs(JSON.stringify(wf, null, 3)) : JSON.stringify(wf, null, 3)}</pre>
                     </Tab>
                     <Tab eventKey={5} title="Edit input">
                         &nbsp;&nbsp;


### PR DESCRIPTION
Added a new **UnescapeButton** component into `ui/src/components/common` that escapes and unescapes JSON on element. ID of element is passed through the `target` argument.

Also added the button in the following places:
In Workflow detail:
- Task Detail Input/Output
- Input/Output tab
- JSON tab

In Grapher component:
- Summary tab Input/Output
- JSON Tab
- Logs Tab (not sure if needed?)