### PR TITLE
Metrics logging collector

### DIFF
--- a/contribs/build.gradle
+++ b/contribs/build.gradle
@@ -19,4 +19,5 @@ dependencies {
 	compile "org.apache.kafka:kafka-clients:2.2.0"
 	testCompile "org.eclipse.jetty:jetty-server:${revJetteyServer}"
 	testCompile "org.eclipse.jetty:jetty-servlet:${revJettyServlet}"
+	compile "com.netflix.spectator:spectator-reg-metrics3:${revSpectator}"
 }

--- a/contribs/src/main/java/com/netflix/conductor/contribs/metrics/LoggingMetricsModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/metrics/LoggingMetricsModule.java
@@ -1,0 +1,70 @@
+package com.netflix.conductor.contribs.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Slf4jReporter;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.netflix.conductor.core.config.Configuration;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Metrics logging reporter, dumping all metrics into an Slf4J logger.
+ * <p>
+ * Enable in config:
+ * conductor.additional.modules=com.netflix.conductor.contribs.metrics.MetricsRegistryModule,com.netflix.conductor.contribs.metrics.LoggingMetricsModule
+ * <p>
+ * additional config:
+ * com.netflix.conductor.contribs.metrics.LoggingMetricsModule.reportPeriodSeconds=15
+ */
+public class LoggingMetricsModule extends AbstractModule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggingMetricsModule.class);
+
+    // Dedicated logger for metrics
+    // This way one can cleanly separate the metrics stream from rest of the logs
+    private static final Logger METRICS_LOGGER = LoggerFactory.getLogger("ConductorMetrics");
+
+    @Override
+    protected void configure() {
+        LOGGER.info("Logging metrics module initialized");
+        bind(Slf4jReporter.class).toProvider(Slf4jReporterProvider.class).asEagerSingleton();
+    }
+
+    static class Slf4jReporterProvider implements Provider<Slf4jReporter> {
+
+        public static final String PERIOD_CONFIG_KEY = LoggingMetricsModule.class.getName() + ".reportPeriodSeconds";
+        public static final int DEFAULT_PERIOD = 30;
+
+        private final Configuration config;
+        private final MetricRegistry metrics3Registry;
+        private final Logger logger;
+
+        @Inject
+        Slf4jReporterProvider(Configuration config, MetricRegistry metrics3Registry) {
+            this(config, metrics3Registry, METRICS_LOGGER);
+        }
+
+        Slf4jReporterProvider(Configuration config, MetricRegistry metrics3Registry, Logger outputLogger) {
+            this.config = config;
+            this.metrics3Registry = metrics3Registry;
+            this.logger = outputLogger;
+        }
+
+        @Override
+        public Slf4jReporter get() {
+            final Slf4jReporter reporter = Slf4jReporter.forRegistry(metrics3Registry)
+                    .outputTo(logger)
+                    .convertRatesTo(TimeUnit.SECONDS)
+                    .convertDurationsTo(TimeUnit.MILLISECONDS)
+                    .build();
+
+            long period = config.getLongProperty(PERIOD_CONFIG_KEY, DEFAULT_PERIOD);
+            reporter.start(period, TimeUnit.SECONDS);
+            LOGGER.info("Logging metrics reporter started, reporting every {} seconds", period);
+            return reporter;
+        }
+    }
+}

--- a/contribs/src/main/java/com/netflix/conductor/contribs/metrics/MetricsRegistryModule.java
+++ b/contribs/src/main/java/com/netflix/conductor/contribs/metrics/MetricsRegistryModule.java
@@ -1,0 +1,30 @@
+package com.netflix.conductor.contribs.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.inject.AbstractModule;
+import com.netflix.spectator.api.Clock;
+import com.netflix.spectator.api.Spectator;
+import com.netflix.spectator.metrics3.MetricsRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Singleton metrics registry.
+ */
+public class MetricsRegistryModule extends AbstractModule {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsRegistryModule.class);
+
+    public static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
+    public static final MetricsRegistry METRICS_REGISTRY = new MetricsRegistry(Clock.SYSTEM, METRIC_REGISTRY);
+    static {
+        Spectator.globalRegistry().add(METRICS_REGISTRY);
+    }
+
+    @Override
+    protected void configure() {
+        LOGGER.info("Metrics registry module initialized");
+        bind(MetricRegistry.class).toInstance(METRIC_REGISTRY);
+        bind(MetricsRegistry.class).toInstance(METRICS_REGISTRY);
+    }
+}

--- a/contribs/src/test/java/com/netflix/conductor/contribs/metrics/LoggingMetricsModuleTest.java
+++ b/contribs/src/test/java/com/netflix/conductor/contribs/metrics/LoggingMetricsModuleTest.java
@@ -1,0 +1,34 @@
+package com.netflix.conductor.contribs.metrics;
+
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import com.codahale.metrics.Slf4jReporter;
+import com.netflix.conductor.core.config.Configuration;
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.slf4j.Logger;
+
+public class LoggingMetricsModuleTest {
+
+    @Test
+    public void testCollector() {
+        Logger logger = mock(Logger.class);
+        doReturn(true).when(logger).isInfoEnabled(null);
+
+        Configuration cfg = mock(Configuration.class);
+        doReturn(1L).when(cfg).getLongProperty(anyString(), anyLong());
+
+        LoggingMetricsModule.Slf4jReporterProvider logMetrics =
+                new LoggingMetricsModule.Slf4jReporterProvider(cfg, MetricsRegistryModule.METRIC_REGISTRY, logger);
+
+        MetricsRegistryModule.METRIC_REGISTRY.counter("test").inc();
+        Slf4jReporter slf4jReporter = logMetrics.get();
+
+        verify(logger, timeout(TimeUnit.SECONDS.toMillis(10))).isInfoEnabled(null);
+    }
+}

--- a/docker/server/bin/startup.sh
+++ b/docker/server/bin/startup.sh
@@ -9,6 +9,10 @@ echo "Property file: $CONFIG_PROP"
 echo $CONFIG_PROP
 export config_file=
 
+echo "Log4j file: $LOG4J_PROP"
+echo $LOG4J_PROP
+export log4j_file=
+
 if [ -z "$CONFIG_PROP" ];
   then
     echo "Using an in-memory instance of conductor";
@@ -18,4 +22,12 @@ if [ -z "$CONFIG_PROP" ];
     export config_file=/app/config/$CONFIG_PROP
 fi
 
-java -jar conductor-server-*-all.jar $config_file
+if [ -z "$LOG4J_PROP" ];
+  then
+    export log4j_file=/app/config/log4j.properties
+  else
+    echo "Using '$LOG4J_PROP'";
+    export log4j_file=/app/config/$LOG4J_PROP
+fi
+
+java -jar conductor-server-*-all.jar $config_file $log4j_file

--- a/docker/server/config/config.properties
+++ b/docker/server/config/config.properties
@@ -53,5 +53,9 @@ workflow.elasticsearch.version=6
 # Additional modules (optional)
 # conductor.additional.modules=class_extending_com.google.inject.AbstractModule
 
+# Additional modules for metrics collection (optional)
+conductor.additional.modules=com.netflix.conductor.contribs.metrics.MetricsRegistryModule,com.netflix.conductor.contribs.metrics.LoggingMetricsModule
+com.netflix.conductor.contribs.metrics.LoggingMetricsModule.reportPeriodSeconds=15
+
 # Load sample kitchen sink workflow
 loadSample=false

--- a/docker/server/config/log4j-file-appender.properties
+++ b/docker/server/config/log4j-file-appender.properties
@@ -1,0 +1,40 @@
+#
+# Copyright 2017 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO,console,file
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %5p [%t] (%C) - %m%n
+
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=/app/logs/conductor.log
+log4j.appender.file.MaxFileSize=10MB
+log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{ISO8601} %5p [%t] (%C) - %m%n
+
+# Dedicated file appender for metrics
+log4j.appender.fileMetrics=org.apache.log4j.RollingFileAppender
+log4j.appender.fileMetrics.File=/app/logs/metrics.log
+log4j.appender.fileMetrics.MaxFileSize=10MB
+log4j.appender.fileMetrics.MaxBackupIndex=10
+log4j.appender.fileMetrics.layout=org.apache.log4j.PatternLayout
+log4j.appender.fileMetrics.layout.ConversionPattern=%d{ISO8601} %5p [%t] (%C) - %m%n
+
+log4j.logger.ConductorMetrics=INFO,console,fileMetrics
+log4j.additivity.ConductorMetrics=false
+

--- a/docker/server/config/log4j.properties
+++ b/docker/server/config/log4j.properties
@@ -1,0 +1,25 @@
+#
+# Copyright 2017 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
This is mirror of https://github.com/Netflix/conductor/pull/1637

Add log4j metrics collector into contribs/ project.
This new component can be enabled via configuration and dump collected
metrics periodically into a log4j appender (file, console...).

Also allow log4j properties customization.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>