### PR TITLE
Add jcenter to fix missing dependencies from netflix repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,16 +75,10 @@ allprojects {
          * This repository locates artifacts that don't exist in maven central but we had to backup from jcenter
          * The exclusiveContent
          */
-        exclusiveContent {
-            forRepository {
                 maven {
                     url "https://artifactory-oss.prod.netflix.net/artifactory/required-jcenter-modules-backup"
                 }
-            }
-            filter {
-                includeGroupByRegex "com\\.github\\.vmg.*"
-            }
-        }
+	jcenter()
     }
 
     dependencyManagement {


### PR DESCRIPTION
Quickfix to: https://github.com/Netflix/conductor/issues/2446

... just add jcenter repo (it should work for downloads) since netflix
repo no longer holds some of the dependencies of conductor

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>

## Summary
Describe the changes made in this PR.

## Test Plan
Steps to test or reproduce.

## Other comments
