### PR TITLE
PSQL External payload storage deduplication

### DIFF
--- a/client/src/main/java/com/netflix/conductor/client/http/ClientBase.java
+++ b/client/src/main/java/com/netflix/conductor/client/http/ClientBase.java
@@ -274,7 +274,8 @@ public abstract class ClientBase {
                         || payloadType.equals(ExternalPayloadStorage.PayloadType.TASK_OUTPUT),
                 "Payload type must be workflow input or task output");
         ExternalStorageLocation externalStorageLocation =
-                payloadStorage.getLocation(ExternalPayloadStorage.Operation.WRITE, payloadType, "");
+                payloadStorage.getLocation(
+                        ExternalPayloadStorage.Operation.WRITE, payloadType, "", payloadBytes);
         payloadStorage.upload(
                 externalStorageLocation.getUri(),
                 new ByteArrayInputStream(payloadBytes),

--- a/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
@@ -46,10 +46,19 @@ public interface ExternalPayloadStorage {
      */
     ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path);
 
-    default ExternalStorageLocation getLocation(Operation operation,
-                                                PayloadType payloadType,
-                                                String path,
-                                                byte[] payloadBytes) {
+    /**
+     * Obtain an uri used to store/access a json payload in external storage.
+     *
+     * @param operation the type of {@link Operation} to be performed with the uri
+     * @param payloadType the {@link PayloadType} that is being accessed at the uri
+     * @param path (optional) the relative path for which the external storage location object is to
+     *     be populated. If path is not specified, it will be computed and populated.
+     * @param payloadBytes for calculating md5 digest which is used for objectKey
+     * @return a {@link ExternalStorageLocation} object which contains the uri and the path for the
+     *     json payload
+     */
+    default ExternalStorageLocation getLocation(
+            Operation operation, PayloadType payloadType, String path, byte[] payloadBytes) {
         return getLocation(operation, payloadType, path);
     }
 

--- a/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
@@ -47,13 +47,14 @@ public interface ExternalPayloadStorage {
     ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path);
 
     /**
-     * Obtain an uri used to store/access a json payload in external storage.
+     * Obtain an uri used to store/access a json payload in external storage with deduplication of data
+     *      based on payloadBytes digest.
      *
      * @param operation the type of {@link Operation} to be performed with the uri
      * @param payloadType the {@link PayloadType} that is being accessed at the uri
      * @param path (optional) the relative path for which the external storage location object is to
      *     be populated. If path is not specified, it will be computed and populated.
-     * @param payloadBytes for calculating md5 digest which is used for objectKey
+     * @param payloadBytes for calculating digest which is used for objectKey
      * @return a {@link ExternalStorageLocation} object which contains the uri and the path for the
      *     json payload
      */

--- a/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
@@ -46,6 +46,13 @@ public interface ExternalPayloadStorage {
      */
     ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path);
 
+    default ExternalStorageLocation getLocation(Operation operation,
+                                                PayloadType payloadType,
+                                                String path,
+                                                byte[] payloadBytes) {
+        return getLocation(operation, payloadType, path);
+    }
+
     /**
      * Upload a json payload to the specified external storage location.
      *

--- a/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
+++ b/common/src/main/java/com/netflix/conductor/common/utils/ExternalPayloadStorage.java
@@ -47,8 +47,8 @@ public interface ExternalPayloadStorage {
     ExternalStorageLocation getLocation(Operation operation, PayloadType payloadType, String path);
 
     /**
-     * Obtain an uri used to store/access a json payload in external storage with deduplication of data
-     *      based on payloadBytes digest.
+     * Obtain an uri used to store/access a json payload in external storage with deduplication of
+     * data based on payloadBytes digest.
      *
      * @param operation the type of {@link Operation} to be performed with the uri
      * @param payloadType the {@link PayloadType} that is being accessed at the uri

--- a/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
+++ b/core/src/main/java/com/netflix/conductor/core/utils/ExternalPayloadStorageUtils.java
@@ -207,7 +207,7 @@ public class ExternalPayloadStorageUtils {
             byte[] payloadBytes, long payloadSize, ExternalPayloadStorage.PayloadType payloadType) {
         ExternalStorageLocation location =
                 externalPayloadStorage.getLocation(
-                        ExternalPayloadStorage.Operation.WRITE, payloadType, "");
+                        ExternalPayloadStorage.Operation.WRITE, payloadType, "", payloadBytes);
         externalPayloadStorage.upload(
                 location.getPath(), new ByteArrayInputStream(payloadBytes), payloadSize);
         return location.getPath();

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -48,6 +48,7 @@ ext {
     revMockServerClient = '5.11.2'
     revNatsStreaming = '0.5.0'
     revOpenapi = '1.6.+'
+    revCodec = '1.15'
     revPowerMock = '2.0.9'
     revPrometheus = '0.9.0'
     revProtoBuf = '3.13.0'

--- a/postgres-external-storage/build.gradle
+++ b/postgres-external-storage/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.springframework.boot:spring-boot-starter-web'
 
+    implementation 'commons-codec:commons-codec:1.15'
     implementation 'org.postgresql:postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.flywaydb:flyway-core'

--- a/postgres-external-storage/build.gradle
+++ b/postgres-external-storage/build.gradle
@@ -17,11 +17,11 @@ dependencies {
     compileOnly 'org.springframework.boot:spring-boot-starter'
     compileOnly 'org.springframework.boot:spring-boot-starter-web'
 
-    implementation 'commons-codec:commons-codec:1.15'
     implementation 'org.postgresql:postgresql'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.flywaydb:flyway-core'
     implementation "org.springdoc:springdoc-openapi-ui:${revOpenapi}"
+    implementation "commons-codec:commons-codec:${revCodec}"
 
     testImplementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation "org.testcontainers:postgresql:${revTestContainer}"

--- a/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorage.java
+++ b/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorage.java
@@ -118,7 +118,7 @@ public class PostgresPayloadStorage implements ExternalPayloadStorage {
             stmt.setString(1, key);
             stmt.setBinaryStream(2, payload, payloadSize);
             if (stmt.executeUpdate() == 0) {
-                LOGGER.warn(
+                LOGGER.debug(
                         "Data wasn't uploaded into External PostgreSQL database key: {}, payload size: {}",
                         key,
                         payloadSize);

--- a/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorage.java
+++ b/postgres-external-storage/src/main/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorage.java
@@ -117,15 +117,9 @@ public class PostgresPayloadStorage implements ExternalPayloadStorage {
                                         + "DO UPDATE SET created_on=CURRENT_TIMESTAMP")) {
             stmt.setString(1, key);
             stmt.setBinaryStream(2, payload, payloadSize);
-            if (stmt.executeUpdate() == 0) {
-                LOGGER.debug(
-                        "Data wasn't uploaded into External PostgreSQL database key: {}, payload size: {}",
-                        key,
-                        payloadSize);
-            } else {
-                LOGGER.debug(
-                        "External PostgreSQL uploaded key: {}, payload size: {}", key, payloadSize);
-            }
+            stmt.executeUpdate();
+            LOGGER.debug(
+                    "External PostgreSQL uploaded key: {}, payload size: {}", key, payloadSize);
         } catch (SQLException e) {
             String msg = "Error uploading data into External PostgreSQL";
             LOGGER.error(msg, e);

--- a/postgres-external-storage/src/test/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorageTest.java
+++ b/postgres-external-storage/src/test/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorageTest.java
@@ -113,7 +113,7 @@ public class PostgresPayloadStorageTest {
         stmt.executeUpdate();
     }
 
-    @Test(timeout = 60*1000)
+    @Test(timeout = 60 * 1000)
     public void testMultithreadDownload()
             throws ExecutionException, InterruptedException, SQLException, IOException {
         AtomicInteger threadCounter = new AtomicInteger(0);
@@ -188,7 +188,7 @@ public class PostgresPayloadStorageTest {
         assertCount(5);
     }
 
-    @Test(timeout = 60*1000)
+    @Test(timeout = 60 * 1000)
     public void testMultithreadInsert()
             throws SQLException, ExecutionException, InterruptedException {
         AtomicInteger threadCounter = new AtomicInteger(0);

--- a/postgres-external-storage/src/test/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorageTest.java
+++ b/postgres-external-storage/src/test/java/com/netflix/conductor/postgres/storage/PostgresPayloadStorageTest.java
@@ -113,7 +113,7 @@ public class PostgresPayloadStorageTest {
         stmt.executeUpdate();
     }
 
-    @Test
+    @Test(timeout = 60*1000)
     public void testMultithreadDownload()
             throws ExecutionException, InterruptedException, SQLException, IOException {
         AtomicInteger threadCounter = new AtomicInteger(0);
@@ -188,7 +188,7 @@ public class PostgresPayloadStorageTest {
         assertCount(5);
     }
 
-    @Test
+    @Test(timeout = 60*1000)
     public void testMultithreadInsert()
             throws SQLException, ExecutionException, InterruptedException {
         AtomicInteger threadCounter = new AtomicInteger(0);


### PR DESCRIPTION
FIXME: add missing javadocs
FIXME: use the new getLocation where necessary
FIXME: COntribute also to upstream (conductor + conductor-contrib)

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>

Pull Request type
----

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
