### PR TITLE
Make tests inside conductor-community runnable from conductor

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -70,4 +70,9 @@ include ':conductor-community:persistence:common-persistence'
 include ':conductor-community:persistence:postgres-persistence'
 include ':conductor-community:archive'
 
-rootProject.children.each {it.name="conductor-${it.name}"}
+(rootProject.children).each {
+    if(it.name == "conductor-community") {
+        return;
+    }
+    it.name="conductor-${it.name}"
+}


### PR DESCRIPTION
Do not prepend "conductor-" to "conductor-community" subprojects. They would be named e.g. conductor-conductor-community:archive which makes them not runnable with gradlew :conductor-conductor-community:archive:test

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
