### PR TITLE
Enable locking in conductor

### DIFF
--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -35,12 +35,12 @@ conductor.metrics-logger.enable=false
 conductor.metrics-prometheus.enabled=false
 
 # Increase payload threshold limits for transferring big schemas to PostgreSQL
-conductor.app.workflowInputPayloadSizeThreshold=10
-conductor.app.workflowOutputPayloadSizeThreshold=10
+conductor.app.workflowInputPayloadSizeThreshold=85
+conductor.app.workflowOutputPayloadSizeThreshold=85
 conductor.app.maxWorkflowInputPayloadSizeThreshold=1024000
 conductor.app.maxWorkflowOutputPayloadSizeThreshold=1024000
-conductor.app.taskInputPayloadSizeThreshold=10
-conductor.app.taskOutputPayloadSizeThreshold=10
+conductor.app.taskInputPayloadSizeThreshold=85
+conductor.app.taskOutputPayloadSizeThreshold=85
 conductor.app.maxTaskInputPayloadSizeThreshold=1024000
 conductor.app.maxTaskOutputPayloadSizeThreshold=1024000
 
@@ -55,6 +55,12 @@ conductor.external-payload-storage.postgres.url=jdbc:postgresql://localhost:5432
 conductor.external-payload-storage.postgres.username=postgres
 conductor.external-payload-storage.postgres.password=postgres
 
+conductor.app.executorServiceMaxThreadCount=100
+conductor.app.systemTaskWorkerCallbackDuration=10
+conductor.app.workflowOffsetTimeout=5
 conductor.app.taskExecutionPostponeDuration=0
 
 loadSample=false
+
+conductor.workflow-execution-lock.type=local_only
+conductor.app.workflowExecutionLockEnabled=true


### PR DESCRIPTION
New conductor does not work properly without locking. In case of dynamic fork with subworkdlow, the workflow sweeper/decider and the async subworkflow task can trigger a race condition where a the dynamic fork generates tasks twice which leads to failure.

Local only lock used for the time being. This works onli with a single conductor server ! In case of multiple conductors, we will have to implement locking in postgres (advisory locks).

Also, tweak the configuration for better performance with big dynamic fork based workflows.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>

Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

_Describe the new behavior from this PR, and why it's needed_
Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
