### PR TITLE
Add property for the timeout of sweeper polling for workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Changes to configurations:
 | workflow.executor.service.max.threads | conductor.app.executorServiceMaxThreadCount | 50 |
 | decider.sweep.frequency.seconds | conductor.app.sweepFrequency | 30s |
 | workflow.sweeper.thread.count | conductor.app.sweeperThreadCount | 5 |
+| - | conductor.app.sweeperWorkflowPollTimeout | 2000ms |
 | workflow.event.processor.thread.count | conductor.app.eventProcessorThreadCount | 2 |
 | workflow.event.message.indexing.enabled | conductor.app.eventMessageIndexingEnabled | true |
 | workflow.event.execution.indexing.enabled | conductor.app.eventExecutionIndexingEnabled | true |

--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -45,6 +45,9 @@ public class ConductorProperties {
     /** The number of threads to use to do background sweep on active workflows. */
     private int sweeperThreadCount = Runtime.getRuntime().availableProcessors() * 2;
 
+    /** The timeout (in milliseconds) for the polling of workflows to be swept. */
+    private Duration sweeperWorkflowPollTimeout = Duration.ofMillis(2000);
+
     /** The number of threads to configure the threadpool in the event processor. */
     private int eventProcessorThreadCount = 2;
 
@@ -248,6 +251,14 @@ public class ConductorProperties {
 
     public void setSweeperThreadCount(int sweeperThreadCount) {
         this.sweeperThreadCount = sweeperThreadCount;
+    }
+
+    public Duration getSweeperWorkflowPollTimeout() {
+        return sweeperWorkflowPollTimeout;
+    }
+
+    public void setSweeperWorkflowPollTimeout(Duration sweeperWorkflowPollTimeout) {
+        this.sweeperWorkflowPollTimeout = sweeperWorkflowPollTimeout;
     }
 
     public int getEventProcessorThreadCount() {


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR
----

Adds a new property to configure the timeout that the sweeper thread will poll for workflows to sweep.
It was hard coded as 2000 ms, which for certain environments can lead to an increase in the overall duration of a workflow execution, as seen with @marosmars.
This is especially relevant for environments with low amounts of workflows executing at a given time, coupled with moderate to high CPU count, and in workflows with several SUB_WORKFLOW tasks.

Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
