### PR TITLE
[FM-751] Add system task offset evaluation strategy

### DIFF
--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -25,7 +25,6 @@ import org.springframework.util.unit.DataSize;
 import org.springframework.util.unit.DataUnit;
 
 import com.netflix.conductor.common.metadata.tasks.TaskType;
-import com.netflix.conductor.core.execution.offset.OffsetEvaluationStrategy;
 
 @ConfigurationProperties("conductor.app")
 public class ConductorProperties {

--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -24,6 +24,9 @@ import org.springframework.boot.convert.DurationUnit;
 import org.springframework.util.unit.DataSize;
 import org.springframework.util.unit.DataUnit;
 
+import com.netflix.conductor.common.metadata.tasks.TaskType;
+import com.netflix.conductor.core.execution.offset.OffsetEvaluationStrategy;
+
 @ConfigurationProperties("conductor.app")
 public class ConductorProperties {
 
@@ -96,6 +99,15 @@ public class ConductorProperties {
      */
     @DurationUnit(ChronoUnit.SECONDS)
     private Duration systemTaskWorkerCallbackDuration = Duration.ofSeconds(30);
+
+    /**
+     * The strategy to be used for evaluation of the offset for a postponed system task of certain
+     * type.<br>
+     * Tasks that are not listed here use {@link
+     * ConductorProperties#systemTaskWorkerCallbackDuration} value.
+     */
+    private Map<TaskType, OffsetEvaluationStrategy> systemTaskOffsetEvaluation =
+            Map.of(TaskType.JOIN, OffsetEvaluationStrategy.BACKOFF_TO_DEFAULT_OFFSET);
 
     /**
      * The interval (in milliseconds) at which system task queues will be polled by the system task
@@ -351,6 +363,15 @@ public class ConductorProperties {
 
     public Duration getSystemTaskWorkerCallbackDuration() {
         return systemTaskWorkerCallbackDuration;
+    }
+
+    public void setSystemTaskOffsetEvaluation(
+            final Map<TaskType, OffsetEvaluationStrategy> systemTaskOffsetEvaluation) {
+        this.systemTaskOffsetEvaluation = systemTaskOffsetEvaluation;
+    }
+
+    public Map<TaskType, OffsetEvaluationStrategy> getSystemTaskOffsetEvaluation() {
+        return systemTaskOffsetEvaluation;
     }
 
     public void setSystemTaskWorkerCallbackDuration(Duration systemTaskWorkerCallbackDuration) {

--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -14,6 +14,7 @@ package com.netflix.conductor.core.config;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -107,6 +108,24 @@ public class ConductorProperties {
      */
     private Map<TaskType, OffsetEvaluationStrategy> systemTaskOffsetEvaluation =
             Map.of(TaskType.JOIN, OffsetEvaluationStrategy.BACKOFF_TO_DEFAULT_OFFSET);
+
+    /**
+     * The duration of the task execution mapped to the calculated offset of the postponed task
+     * [seconds].<br>
+     * This setting is used only by the {@link OffsetEvaluationStrategy#SCALED_BY_TASK_DURATION}
+     * offset evaluation strategy.<br>
+     * Example: If map contains two entries (10, 30) and (20, 60), then the evaluation offsets for
+     * the postponed tasks in the queue will be calculated according to the following intervals:
+     *
+     * <ul>
+     *   <li><0,10) seconds: offset = 0 seconds
+     *   <li><10-20) seconds: offset = 30 seconds
+     *   <li><20-N) seconds: offset = 60 seconds
+     * </ul>
+     *
+     * By default, the offset is always set to 0 seconds.
+     */
+    private Map<Long, Long> taskDurationToOffsetSteps = Collections.emptyMap();
 
     /**
      * The interval (in milliseconds) at which system task queues will be polled by the system task
@@ -371,6 +390,14 @@ public class ConductorProperties {
 
     public Map<TaskType, OffsetEvaluationStrategy> getSystemTaskOffsetEvaluation() {
         return systemTaskOffsetEvaluation;
+    }
+
+    public Map<Long, Long> getTaskDurationToOffsetSteps() {
+        return taskDurationToOffsetSteps;
+    }
+
+    public void setTaskDurationToOffsetSteps(Map<Long, Long> taskDurationToOffsetSteps) {
+        this.taskDurationToOffsetSteps = taskDurationToOffsetSteps;
     }
 
     public void setSystemTaskWorkerCallbackDuration(Duration systemTaskWorkerCallbackDuration) {

--- a/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/ConductorProperties.java
@@ -114,13 +114,13 @@ public class ConductorProperties {
      * [seconds].<br>
      * This setting is used only by the {@link OffsetEvaluationStrategy#SCALED_BY_TASK_DURATION}
      * offset evaluation strategy.<br>
-     * Example: If map contains two entries (10, 30) and (20, 60), then the evaluation offsets for
-     * the postponed tasks in the queue will be calculated according to the following intervals:
+     * Example: If settings contain two entries (10, 30) and (20, 60), then the evaluation offsets
+     * for the postponed tasks in the queue will be calculated according to the following intervals:
      *
      * <ul>
      *   <li><0,10) seconds: offset = 0 seconds
-     *   <li><10-20) seconds: offset = 30 seconds
-     *   <li><20-N) seconds: offset = 60 seconds
+     *   <li><10,20) seconds: offset = 30 seconds
+     *   <li><20,N) seconds: offset = 60 seconds
      * </ul>
      *
      * By default, the offset is always set to 0 seconds.

--- a/core/src/main/java/com/netflix/conductor/core/config/OffsetEvaluationStrategy.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/OffsetEvaluationStrategy.java
@@ -10,48 +10,25 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package com.netflix.conductor.core.execution.offset;
+package com.netflix.conductor.core.config;
 
 /**
  * Strategies used for computation of the task offset. The offset is used to postpone the task
  * execution in the queue.
  */
 public enum OffsetEvaluationStrategy {
-    /**
-     * Constant offset evaluation strategy - using default offset value.
-     *
-     * @see ConstantDefaultOffsetEvaluation
-     */
-    CONSTANT_DEFAULT_OFFSET(new ConstantDefaultOffsetEvaluation()),
+    /** Constant offset evaluation strategy - using default offset value. */
+    CONSTANT_DEFAULT_OFFSET,
     /**
      * Computes the evaluation offset for a postponed task based on the task's poll count and a
      * default offset. In this strategy offset increases exponentially until it reaches the default
      * offset.
-     *
-     * @see BackoffToDefaultOffsetEvaluation
      */
-    BACKOFF_TO_DEFAULT_OFFSET(new BackoffToDefaultOffsetEvaluation()),
+    BACKOFF_TO_DEFAULT_OFFSET,
     /**
      * Computes the evaluation offset for a postponed task based on the queue size and the task's
      * poll count. In this strategy offset increases exponentially until it reaches the (default
      * offset * queue size) value.
-     *
-     * @see ScaledByQueueSizeOffsetEvaluation
      */
-    SCALED_BY_QUEUE_SIZE(new ScaledByQueueSizeOffsetEvaluation());
-
-    private final TaskOffsetEvaluation taskOffsetEvaluation;
-
-    OffsetEvaluationStrategy(final TaskOffsetEvaluation taskOffsetEvaluation) {
-        this.taskOffsetEvaluation = taskOffsetEvaluation;
-    }
-
-    /**
-     * Get the task offset evaluation strategy.
-     *
-     * @return {@link TaskOffsetEvaluation}
-     */
-    public TaskOffsetEvaluation getTaskOffsetEvaluation() {
-        return taskOffsetEvaluation;
-    }
+    SCALED_BY_QUEUE_SIZE;
 }

--- a/core/src/main/java/com/netflix/conductor/core/config/OffsetEvaluationStrategy.java
+++ b/core/src/main/java/com/netflix/conductor/core/config/OffsetEvaluationStrategy.java
@@ -30,5 +30,13 @@ public enum OffsetEvaluationStrategy {
      * poll count. In this strategy offset increases exponentially until it reaches the (default
      * offset * queue size) value.
      */
-    SCALED_BY_QUEUE_SIZE;
+    SCALED_BY_QUEUE_SIZE,
+    /**
+     * Computes the evaluation offset for a postponed task based on the task's duration. In this
+     * strategy offset increases by steps that are proportional to the task's duration and defined
+     * by the user settings.
+     *
+     * @see ConductorProperties#getTaskDurationToOffsetSteps() setting used to define the steps
+     */
+    SCALED_BY_TASK_DURATION
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/BackoffToDefaultOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/BackoffToDefaultOffsetEvaluation.java
@@ -12,6 +12,10 @@
  */
 package com.netflix.conductor.core.execution.offset;
 
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.config.OffsetEvaluationStrategy;
 import com.netflix.conductor.model.TaskModel;
 
 /**
@@ -31,11 +35,22 @@ import com.netflix.conductor.model.TaskModel;
  * <tr><td>5</td><td>10</td><td>10</td></tr>
  * </table>
  */
+@Component
 final class BackoffToDefaultOffsetEvaluation implements TaskOffsetEvaluation {
 
+    private final long defaultOffset;
+
+    BackoffToDefaultOffsetEvaluation(final ConductorProperties conductorProperties) {
+        defaultOffset = conductorProperties.getSystemTaskWorkerCallbackDuration().toSeconds();
+    }
+
     @Override
-    public long computeEvaluationOffset(
-            final TaskModel taskModel, final long defaultOffset, final int queueSize) {
+    public OffsetEvaluationStrategy type() {
+        return OffsetEvaluationStrategy.BACKOFF_TO_DEFAULT_OFFSET;
+    }
+
+    @Override
+    public long computeEvaluationOffset(final TaskModel taskModel, final int queueSize) {
         final int index = taskModel.getPollCount() > 0 ? taskModel.getPollCount() - 1 : 0;
         if (index == 0) {
             return 0L;

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/BackoffToDefaultOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/BackoffToDefaultOffsetEvaluation.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import com.netflix.conductor.model.TaskModel;
+
+/**
+ * Computes the evaluation offset for a postponed task based on the task's poll count and a default
+ * offset. In this strategy offset increases exponentially until it reaches the default offset.<br>
+ * This strategy is appropriate for queues that require low latency of all tasks.<br>
+ * Sample evaluationOffset for different pollCounts and defaultOffset (queueSize is ignored):
+ *
+ * <table>
+ * <tr><th>pollCount</th><th>defaultOffset</th><th>evaluationOffset</th></tr>
+ * <tr><td>0</td><td>5</td><td>0</td></tr>
+ * <tr><td>1</td><td>5</td><td>0</td></tr>
+ * <tr><td>2</td><td>5</td><td>2</td></tr>
+ * <tr><td>3</td><td>5</td><td>4</td></tr>
+ * <tr><td>4</td><td>5</td><td>5</td></tr>
+ * <tr><td>4</td><td>10</td><td>8</td></tr>
+ * <tr><td>5</td><td>10</td><td>10</td></tr>
+ * </table>
+ */
+final class BackoffToDefaultOffsetEvaluation implements TaskOffsetEvaluation {
+
+    @Override
+    public long computeEvaluationOffset(
+            final TaskModel taskModel, final long defaultOffset, final int queueSize) {
+        final int index = taskModel.getPollCount() > 0 ? taskModel.getPollCount() - 1 : 0;
+        if (index == 0) {
+            return 0L;
+        }
+        return Math.min((long) Math.pow(2, index), defaultOffset);
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/ConstantDefaultOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/ConstantDefaultOffsetEvaluation.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import com.netflix.conductor.model.TaskModel;
+
+/** Dummy implementation of {@link TaskOffsetEvaluation} that always returns the default offset. */
+final class ConstantDefaultOffsetEvaluation implements TaskOffsetEvaluation {
+    @Override
+    public long computeEvaluationOffset(
+            final TaskModel taskModel, final long defaultOffset, final int queueSize) {
+        return defaultOffset;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/ConstantDefaultOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/ConstantDefaultOffsetEvaluation.java
@@ -12,13 +12,29 @@
  */
 package com.netflix.conductor.core.execution.offset;
 
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.config.OffsetEvaluationStrategy;
 import com.netflix.conductor.model.TaskModel;
 
 /** Dummy implementation of {@link TaskOffsetEvaluation} that always returns the default offset. */
+@Component
 final class ConstantDefaultOffsetEvaluation implements TaskOffsetEvaluation {
+
+    private final long defaultOffset;
+
+    ConstantDefaultOffsetEvaluation(final ConductorProperties conductorProperties) {
+        defaultOffset = conductorProperties.getSystemTaskWorkerCallbackDuration().toSeconds();
+    }
+
     @Override
-    public long computeEvaluationOffset(
-            final TaskModel taskModel, final long defaultOffset, final int queueSize) {
+    public OffsetEvaluationStrategy type() {
+        return OffsetEvaluationStrategy.CONSTANT_DEFAULT_OFFSET;
+    }
+
+    @Override
+    public long computeEvaluationOffset(final TaskModel taskModel, final int queueSize) {
         return defaultOffset;
     }
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/OffsetEvaluationStrategy.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/OffsetEvaluationStrategy.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+/**
+ * Strategies used for computation of the task offset. The offset is used to postpone the task
+ * execution in the queue.
+ */
+public enum OffsetEvaluationStrategy {
+    /**
+     * Constant offset evaluation strategy - using default offset value.
+     *
+     * @see ConstantDefaultOffsetEvaluation
+     */
+    CONSTANT_DEFAULT_OFFSET(new ConstantDefaultOffsetEvaluation()),
+    /**
+     * Computes the evaluation offset for a postponed task based on the task's poll count and a
+     * default offset. In this strategy offset increases exponentially until it reaches the default
+     * offset.
+     *
+     * @see BackoffToDefaultOffsetEvaluation
+     */
+    BACKOFF_TO_DEFAULT_OFFSET(new BackoffToDefaultOffsetEvaluation()),
+    /**
+     * Computes the evaluation offset for a postponed task based on the queue size and the task's
+     * poll count. In this strategy offset increases exponentially until it reaches the (default
+     * offset * queue size) value.
+     *
+     * @see ScaledByQueueSizeOffsetEvaluation
+     */
+    SCALED_BY_QUEUE_SIZE(new ScaledByQueueSizeOffsetEvaluation());
+
+    private final TaskOffsetEvaluation taskOffsetEvaluation;
+
+    OffsetEvaluationStrategy(final TaskOffsetEvaluation taskOffsetEvaluation) {
+        this.taskOffsetEvaluation = taskOffsetEvaluation;
+    }
+
+    /**
+     * Get the task offset evaluation strategy.
+     *
+     * @return {@link TaskOffsetEvaluation}
+     */
+    public TaskOffsetEvaluation getTaskOffsetEvaluation() {
+        return taskOffsetEvaluation;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/ScaledByQueueSizeOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/ScaledByQueueSizeOffsetEvaluation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import com.netflix.conductor.model.TaskModel;
+
+/**
+ * Computes the evaluation offset for a postponed task based on the queue size and the task's poll
+ * count. In this strategy offset increases exponentially until it reaches the (default offset *
+ * queue size) value.<br>
+ * This strategy is appropriate for relatively big queues (100-1000s tasks) that contain
+ * long-running tasks (days-weeks) with high number of poll-counts.<br>
+ * Sample evaluationOffset for different pollCounts, defaultOffset and queueSize:
+ *
+ * <table>
+ * <tr><th>pollCount</th><th>defaultOffset</th><th>queueSize</th><th>evaluationOffset</th></tr>
+ * <tr><td>0</td><td>-</td><td>-</td><td>0</td></tr>
+ * <tr><td>1</td><td>-</td><td>-</td><td>0</td></tr>
+ * <tr><td>2</td><td>5</td><td>1</td><td>2</td></tr>
+ * <tr><td>3</td><td>5</td><td>1</td><td>4</td></tr>
+ * <tr><td>4</td><td>5</td><td>1</td><td>5</td></tr>
+ * <tr><td>4</td><td>5</td><td>0</td><td>5</td></tr>
+ * <tr><td>4</td><td>5</td><td>2</td><td>8</td></tr>
+ * </table>
+ */
+final class ScaledByQueueSizeOffsetEvaluation implements TaskOffsetEvaluation {
+
+    @Override
+    public long computeEvaluationOffset(
+            final TaskModel taskModel, final long defaultOffset, final int queueSize) {
+        int index = taskModel.getPollCount() > 0 ? taskModel.getPollCount() - 1 : 0;
+        if (index == 0) {
+            return 0L;
+        }
+        final long scaledOffset = queueSize > 0 ? queueSize * defaultOffset : defaultOffset;
+        return Math.min((long) Math.pow(2, index), scaledOffset);
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/ScaledByQueueSizeOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/ScaledByQueueSizeOffsetEvaluation.java
@@ -12,6 +12,10 @@
  */
 package com.netflix.conductor.core.execution.offset;
 
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.config.OffsetEvaluationStrategy;
 import com.netflix.conductor.model.TaskModel;
 
 /**
@@ -33,11 +37,22 @@ import com.netflix.conductor.model.TaskModel;
  * <tr><td>4</td><td>5</td><td>2</td><td>8</td></tr>
  * </table>
  */
+@Component
 final class ScaledByQueueSizeOffsetEvaluation implements TaskOffsetEvaluation {
 
+    private final long defaultOffset;
+
+    ScaledByQueueSizeOffsetEvaluation(final ConductorProperties conductorProperties) {
+        defaultOffset = conductorProperties.getSystemTaskWorkerCallbackDuration().toSeconds();
+    }
+
     @Override
-    public long computeEvaluationOffset(
-            final TaskModel taskModel, final long defaultOffset, final int queueSize) {
+    public OffsetEvaluationStrategy type() {
+        return OffsetEvaluationStrategy.SCALED_BY_QUEUE_SIZE;
+    }
+
+    @Override
+    public long computeEvaluationOffset(final TaskModel taskModel, final int queueSize) {
         int index = taskModel.getPollCount() > 0 ? taskModel.getPollCount() - 1 : 0;
         if (index == 0) {
             return 0L;

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/ScaledByTaskDurationOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/ScaledByTaskDurationOffsetEvaluation.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.core.config.OffsetEvaluationStrategy;
+import com.netflix.conductor.model.TaskModel;
+
+/**
+ * Computes the evaluation offset for a postponed task based on the task's duration and settings
+ * that define the offset for different levels of task durations.<br>
+ * In this strategy offset increases by steps based on settings that define the offset for different
+ * levels of task durations. Task duration is derived from {@link TaskModel#getScheduledTime()} and
+ * current time.<br>
+ * This strategy is appropriate for tasks that have a wide range of durations and the offset should
+ * be scaled based on the task's duration.<br>
+ * The defined keys in the settings compose the duration intervals for which the offset will be set
+ * to the corresponding value: <0, d1) = 0, <d1, d2) = d1, <d2, d3) = d2.<br>
+ * The order of the keys is not important as the map is sorted by the key before the evaluation.
+ */
+@Component
+final class ScaledByTaskDurationOffsetEvaluation implements TaskOffsetEvaluation {
+
+    private final Map<Long, Long> taskDurationToOffsetSteps;
+
+    ScaledByTaskDurationOffsetEvaluation(final ConductorProperties conductorProperties) {
+        taskDurationToOffsetSteps = sortByTaskDuration(conductorProperties);
+    }
+
+    private static LinkedHashMap<Long, Long> sortByTaskDuration(
+            final ConductorProperties conductorProperties) {
+        return conductorProperties.getTaskDurationToOffsetSteps().entrySet().stream()
+                .sorted(Entry.comparingByKey(Comparator.reverseOrder()))
+                .collect(
+                        Collectors.toMap(
+                                Entry::getKey,
+                                Entry::getValue,
+                                (e1, e2) -> e1,
+                                LinkedHashMap::new));
+    }
+
+    @Override
+    public OffsetEvaluationStrategy type() {
+        return OffsetEvaluationStrategy.SCALED_BY_TASK_DURATION;
+    }
+
+    @Override
+    public long computeEvaluationOffset(final TaskModel taskModel, final int queueSize) {
+        if (taskDurationToOffsetSteps.isEmpty()) {
+            return 0L;
+        }
+        final long taskDuration =
+                (System.currentTimeMillis() - taskModel.getScheduledTime()) / 1000;
+        return taskDurationToOffsetSteps.entrySet().stream()
+                .filter(entry -> taskDuration >= entry.getKey())
+                .map(Entry::getValue)
+                .findFirst()
+                .orElse(0L);
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/TaskOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/TaskOffsetEvaluation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import com.netflix.conductor.model.TaskModel;
+
+/** Service used for computation of the evaluation offset for the postponed task. */
+public sealed interface TaskOffsetEvaluation
+        permits BackoffToDefaultOffsetEvaluation,
+                ConstantDefaultOffsetEvaluation,
+                ScaledByQueueSizeOffsetEvaluation {
+    /**
+     * Compute the evaluation offset for the postponed task.
+     *
+     * @param taskModel details about the postponed task
+     * @param defaultOffset the default offset provided by the configuration properties [seconds]
+     * @param queueSize the actual size of the queue before the task is postponed
+     * @return the computed evaluation offset [seconds]
+     */
+    long computeEvaluationOffset(TaskModel taskModel, long defaultOffset, int queueSize);
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/TaskOffsetEvaluation.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/TaskOffsetEvaluation.java
@@ -12,20 +12,24 @@
  */
 package com.netflix.conductor.core.execution.offset;
 
+import com.netflix.conductor.core.config.OffsetEvaluationStrategy;
 import com.netflix.conductor.model.TaskModel;
 
 /** Service used for computation of the evaluation offset for the postponed task. */
-public sealed interface TaskOffsetEvaluation
-        permits BackoffToDefaultOffsetEvaluation,
-                ConstantDefaultOffsetEvaluation,
-                ScaledByQueueSizeOffsetEvaluation {
+public interface TaskOffsetEvaluation {
+    /**
+     * Get the type of the offset evaluation strategy.
+     *
+     * @return @{@link OffsetEvaluationStrategy}
+     */
+    OffsetEvaluationStrategy type();
+
     /**
      * Compute the evaluation offset for the postponed task.
      *
      * @param taskModel details about the postponed task
-     * @param defaultOffset the default offset provided by the configuration properties [seconds]
      * @param queueSize the actual size of the queue before the task is postponed
      * @return the computed evaluation offset [seconds]
      */
-    long computeEvaluationOffset(TaskModel taskModel, long defaultOffset, int queueSize);
+    long computeEvaluationOffset(TaskModel taskModel, int queueSize);
 }

--- a/core/src/main/java/com/netflix/conductor/core/execution/offset/TaskOffsetEvaluationSelector.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/offset/TaskOffsetEvaluationSelector.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import com.netflix.conductor.core.config.OffsetEvaluationStrategy;
+
+@Component
+public final class TaskOffsetEvaluationSelector {
+
+    private final Map<OffsetEvaluationStrategy, TaskOffsetEvaluation> evaluations;
+
+    @Autowired
+    public TaskOffsetEvaluationSelector(final List<TaskOffsetEvaluation> evaluations) {
+        this.evaluations =
+                evaluations.stream()
+                        .collect(Collectors.toMap(TaskOffsetEvaluation::type, Function.identity()));
+    }
+
+    /**
+     * Get the implementation of the offset evaluation for the given strategy.
+     *
+     * @param strategy the strategy to get the implementation for
+     * @return {@link TaskOffsetEvaluation}
+     * @throws IllegalStateException if no implementation is found for the given strategy
+     */
+    @NonNull
+    public TaskOffsetEvaluation taskOffsetEvaluation(final OffsetEvaluationStrategy strategy) {
+        final var taskOffsetEvaluation = evaluations.get(strategy);
+        if (taskOffsetEvaluation == null) {
+            throw new IllegalStateException(
+                    "No TaskOffsetEvaluation found for strategy: " + strategy);
+        }
+        return taskOffsetEvaluation;
+    }
+}

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/Join.java
@@ -13,7 +13,6 @@
 package com.netflix.conductor.core.execution.tasks;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
@@ -80,15 +79,6 @@ public class Join extends WorkflowSystemTask {
             return true;
         }
         return false;
-    }
-
-    @Override
-    public Optional<Long> getEvaluationOffset(TaskModel taskModel, long defaultOffset) {
-        int index = taskModel.getPollCount() > 0 ? taskModel.getPollCount() - 1 : 0;
-        if (index == 0) {
-            return Optional.of(0L);
-        }
-        return Optional.of(Math.min((long) Math.pow(2, index), defaultOffset));
     }
 
     public boolean isAsync() {

--- a/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java
+++ b/core/src/main/java/com/netflix/conductor/core/execution/tasks/WorkflowSystemTask.java
@@ -65,10 +65,6 @@ public abstract class WorkflowSystemTask {
      */
     public void cancel(WorkflowModel workflow, TaskModel task, WorkflowExecutor workflowExecutor) {}
 
-    public Optional<Long> getEvaluationOffset(TaskModel taskModel, long defaultOffset) {
-        return Optional.empty();
-    }
-
     /**
      * @return True if the task is supposed to be started asynchronously using internal queues.
      */

--- a/core/src/test/java/com/netflix/conductor/core/execution/offset/BackoffToDefaultOffsetEvaluationTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/offset/BackoffToDefaultOffsetEvaluationTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.netflix.conductor.model.TaskModel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BackoffToDefaultOffsetEvaluationTest {
+    private static TaskOffsetEvaluation offsetEvaluation;
+
+    @BeforeAll
+    static void setUp() {
+        offsetEvaluation = new BackoffToDefaultOffsetEvaluation();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        offsetEvaluation = null;
+    }
+
+    @Mock private TaskModel taskModel;
+
+    @ParameterizedTest
+    @CsvSource({"0, 5, 0", "1, 5, 0", "2, 5, 2", "3, 5, 4", "4, 5, 5", "4, 10, 8", "5, 10, 10"})
+    void testComputeEvaluationOffset(
+            final int pollCount, final long defaultOffset, final long expectedOffset) {
+        when(taskModel.getPollCount()).thenReturn(pollCount);
+        final var result = offsetEvaluation.computeEvaluationOffset(taskModel, defaultOffset, 10);
+        assertEquals(expectedOffset, result);
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/offset/ScaledByQueueSizeOffsetEvaluationTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/offset/ScaledByQueueSizeOffsetEvaluationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.netflix.conductor.model.TaskModel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ScaledByQueueSizeOffsetEvaluationTest {
+
+    private static TaskOffsetEvaluation offsetEvaluation;
+
+    @BeforeAll
+    static void setUp() {
+        offsetEvaluation = new ScaledByQueueSizeOffsetEvaluation();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        offsetEvaluation = null;
+    }
+
+    @Mock private TaskModel taskModel;
+
+    @ParameterizedTest
+    @CsvSource({
+        "0, 5, 1, 0",
+        "1, 5, 1, 0",
+        "2, 5, 1, 2",
+        "3, 5, 1, 4",
+        "4, 5, 1, 5",
+        "4, 5, 0, 5",
+        "4, 5, 2, 8"
+    })
+    void testComputeEvaluationOffset(
+            final int pollCount,
+            final long defaultOffset,
+            final int queueSize,
+            final long expectedOffset) {
+        when(taskModel.getPollCount()).thenReturn(pollCount);
+        final var result =
+                offsetEvaluation.computeEvaluationOffset(taskModel, defaultOffset, queueSize);
+        assertEquals(expectedOffset, result);
+    }
+}

--- a/core/src/test/java/com/netflix/conductor/core/execution/offset/ScaledByTaskDurationOffsetEvaluationTest.java
+++ b/core/src/test/java/com/netflix/conductor/core/execution/offset/ScaledByTaskDurationOffsetEvaluationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.netflix.conductor.core.execution.offset;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.netflix.conductor.core.config.ConductorProperties;
+import com.netflix.conductor.model.TaskModel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ScaledByTaskDurationOffsetEvaluationTest {
+
+    @Mock private TaskModel taskModel;
+    @Mock private ConductorProperties conductorProperties;
+
+    private static Stream<Arguments> testOffsetsProvider() {
+        return Stream.of(
+                Arguments.of(Map.of(10L, 30L, 20L, 60L, 30L, 120L), 1L, 0L),
+                Arguments.of(Map.of(10L, 30L, 20L, 60L, 30L, 120L), 11L, 30L),
+                Arguments.of(Map.of(10L, 30L, 20L, 60L, 30L, 120L), 100L, 120L),
+                Arguments.of(Collections.emptyMap(), 20L, 0L),
+                Arguments.of(Map.of(30L, 120L, 20L, 60L, 10L, 0L, 100L, 1200L), 35L, 120L));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testOffsetsProvider")
+    void testComputeEvaluationOffset(
+            final Map<Long, Long> offsets, final long taskDuration, final long expectedOffset) {
+        final long scheduledTime = System.currentTimeMillis() - (taskDuration * 1000);
+        when(conductorProperties.getTaskDurationToOffsetSteps()).thenReturn(offsets);
+        if (!offsets.isEmpty()) {
+            when(taskModel.getScheduledTime()).thenReturn(scheduledTime);
+        }
+
+        final var offsetEvaluation = new ScaledByTaskDurationOffsetEvaluation(conductorProperties);
+        final var result = offsetEvaluation.computeEvaluationOffset(taskModel, 50);
+        assertEquals(expectedOffset, result);
+    }
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -130,7 +130,7 @@ conductor.external-payload-storage.postgres.password=postgres
 
 #### Performance / timer tweaks ####
 conductor.app.systemTaskWorkerCallbackDuration=10
-conductor.app.system-task-offset-evaluation.join=scaled_by_queue_size
+conductor.app.system-task-offset-evaluation.join=backoff_to_default_offset
 conductor.app.workflowOffsetTimeout=10
 #### Performance / timer tweaks end ####
 

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -130,6 +130,7 @@ conductor.external-payload-storage.postgres.password=postgres
 
 #### Performance / timer tweaks ####
 conductor.app.systemTaskWorkerCallbackDuration=10
+conductor.app.system-task-offset-evaluation.join=scaled_by_queue_size
 conductor.app.workflowOffsetTimeout=10
 #### Performance / timer tweaks end ####
 


### PR DESCRIPTION
FM-751 Add system task offset evaluation strategy

Pull Request type
----
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes (Please run `./gradlew generateLock saveLock` to refresh dependencies)
- [ ] WHOSUSING.md
- [ ] Other (please describe):

Changes in this PR
----

    - Added option to customize strategy used for computation
      of a postponed system task per task type:
    
      conductor.app.system-task-offset-evaluation.[task-type]=[strategy]
    
      [task-type] - type of the task, e.g. join, simple, ...
      [strategy] - strategy used for computation of the system task
        offset; currently supported options are:
        a. 'constant_default_offset'
        b. 'backoff_to_default_offset'
        c. 'scaled_by_queue_size'
        d. 'scaled_by_task_duration'
    
    - 'constant_default_offset' - uses constant value of set
      'systemTaskWorkerCallbackDuration' configuration property;
      by default, it is used by all but 'join' system tasks
    - 'backoff_to_default_offset' - scales offset based on task
      poll-count in exponential way (2^n) up to value of the
      'systemTaskWorkerCallbackDuration' configuration property;
      by default, it is used by 'join' system task
    - 'scaled_by_queue_size' - scales offset based on task poll-count
      and actual queue size in exponential way (2^n) up to value of:
      a. 'backoff_to_default_offset', if queue size == 0
      b. 'backoff_to_default_offset'*'queue_size' otherwise
      this strategy is not used in the default configuration
    - 'scaled_by_task_duration' - Computes the evaluation offset for
      a postponed task based on the task's duration and settings that
      define the offset for different levels of task durations.

    Reasoning:
    - New strategies were implemented primarily to solve performance
      issues on join queues that contain a large number of join tasks
      blocked by wait/human actions in some forks for several
      days/weeks.
    - Implemented strategies can easily be extended in the future
      while preserving backwards compatibility.
    - Improved configurability of the task offset evaluation.

Alternatives considered
----
https://nitish1503.medium.com/decoding-challenges-with-netflix-conductor-6a623b47291f - it would require too big changes in the core architecture of the conductor